### PR TITLE
Jbalistreri/reads

### DIFF
--- a/client.py
+++ b/client.py
@@ -2,18 +2,13 @@ import os
 import socket
 import sys
 
-from kvstore.constants import INPUT_PROMPT
+from kvstore.constants import INPUT_PROMPT, LB_NODE
 from kvstore.input import configure_readline, input_to_command, InputValidationError
 from kvstore.server import call_node_with_command
 
 
 def main():
     configure_readline()
-
-    try:
-        connect_to_node = sys.argv[1]
-    except IndexError:
-        connect_to_node = 1
 
     s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     try:
@@ -26,7 +21,7 @@ def main():
                 print(str(e))
                 continue
 
-            response, s = call_node_with_command(command, connect_to_node)
+            response, s = call_node_with_command(command, LB_NODE)
 
             print(response.value + "\n")
             s.close()

--- a/kvstore/constants.py
+++ b/kvstore/constants.py
@@ -7,4 +7,3 @@ INPUT_PROMPT = "> "
 ENTRYPOINT_SOCKET = "entrypoint.socket"
 
 LB_NODE = 0
-LEADER_NODE = 1

--- a/kvstore/constants.py
+++ b/kvstore/constants.py
@@ -5,3 +5,6 @@ NULL = "NULL"
 INPUT_PROMPT = "> "
 
 ENTRYPOINT_SOCKET = "entrypoint.socket"
+
+LB_NODE = 0
+LEADER_NODE = 1

--- a/kvstore/encoding.py
+++ b/kvstore/encoding.py
@@ -100,6 +100,9 @@ class BinaryEncoderDecoder:
         return log_seq_no + key_encoded + val_encoded
 
     def encode(self, command):
+        if command.enum == CommandEnum.EMPTY_RESPONSE:
+            return b''
+
         buf = io.BytesIO()
         buf.write(self.encode_num(command.enum.value))
 

--- a/kvstore/encoding.py
+++ b/kvstore/encoding.py
@@ -153,24 +153,6 @@ class BinaryEncoderDecoder:
             signed=self.signed
         )
 
-    def encode_bool(self, bool):
-        # TODO: this is inefficient - we could encode the boolean as a single bit
-        # reusing the existing number encoding to save time to focus on other
-        # aspects of the project
-        if bool:
-            return self.encode_num(1)
-        else:
-            return self.encode_num(0)
-
-    def decode_bool(self, buf):
-        num, read = self.decode_num(buf)
-        if num == 1:
-            return True, read
-        elif num == 0:
-            return False, read
-        else:
-            raise ValueError(f"Could not decode {num} to bool")
-
     def decode_string(self, buf):
         size, read = self.decode_num(buf)
         return buf.read(size).decode(self.string_encoding), read + size

--- a/kvstore/loadbalancer.py
+++ b/kvstore/loadbalancer.py
@@ -1,44 +1,42 @@
 import random
 import socketserver
 
-from kvstore.constants import ENTRYPOINT_SOCKET, LEADER_NODE
+from kvstore.constants import ENTRYPOINT_SOCKET
 from kvstore.encoding import *
 from kvstore.transport import EntryPointHandler, call_node_with_command, get_socket_fd
 import socket
 
 
 class LoadBalancer:
-    def __init__(self, node_number):
+    def __init__(self, node_number, automatic_failover):
         self.node_number = node_number
         self.en = BinaryEncoderDecoder()
         sockFd = get_socket_fd(node_number)
         self.server = socketserver.UnixStreamServer(sockFd, EntryPointHandler)
         self.server.server = self
+        self.automatic_failover = automatic_failover
 
         self.leader = None
         self.followers = set()
 
-        print("Starting loadbalancer")
+        print("starting loadbalancer")
 
     def registerFollower(self, command):
-        if command.node_number == LEADER_NODE:
-            print(f"Registered node {command.node_number} as the leader")
+        if not self.leader:
+            print(f"registered node {command.node_number} as the leader")
             self.leader = command.node_number
-            self.followers.add(command.node_number)
-            return LBRegistrationInfo(LEADER_NODE, self.followers - set([command.node_number]))
         else:
-            print(f"Registered node {command.node_number} as a follower")
-            self.followers.add(command.node_number)
-            return LBRegistrationInfo(LEADER_NODE, set())
+            print(f"registered node {command.node_number} as a follower")
 
-
+        self.followers.add(command.node_number)
+        return LBRegistrationInfo(self.leader, self.followers)
 
     def get(self, command):
         if len(self.followers) == 0:
-            return StringResponse("No read nodes available")
+            return StringResponse("no read nodes available")
 
-        get_node = random.sample(self.followers, 1)[0]
-        print(f"Reading from node {get_node}")
+        get_node = self._choose_read_node()
+        print(f"reading from node {get_node}")
         try:
             resp, socket = call_node_with_command(command, get_node)
             socket.close()
@@ -48,28 +46,56 @@ class LoadBalancer:
             self.followers.remove(get_node)
             return self.get(command)
 
+    def _choose_read_node(self):
+        # could add options for different types of load balancing here (e.g.
+        # round robin, least loaded, etc.)
+        return random.sample(self.followers, 1)[0]
+
     def set(self, command):
         if self.leader == None:
-            return StringResponse("No write nodes available")
+            return StringResponse("no write nodes available")
 
         try:
             resp, socket = call_node_with_command(command, self.leader)
             socket.close()
-            return resp
         except FileNotFoundError:
-            print(f"unable to reach node {self.leader}. marking as dead")
-            self.leader = None
+            return self._handle_dead_leader(command)
+
+        print(f"writing to node {self.leader}")
+        return resp
+
+    def _handle_dead_leader(self, command):
+        print(f"unable to reach node {self.leader}. marking as dead")
+        self.followers.remove(self.leader)
+        self.leader = None
+        if not self.automatic_failover or len(self.followers) == 0:
             return StringResponse("No write nodes available")
+
+        print(f"starting automatic failover")
+
+        new_leader = random.sample(self.followers, 1)[0]
+        print(f"node {new_leader} elected as new leader")
+
+        self.leader = new_leader
+        updated_info = LBRegistrationInfo(new_leader, self.followers)
+        for f_id in self.followers:
+            print(f"notifying node {f_id} of leadership change")
+            _, s = call_node_with_command(updated_info, f_id)
+            s.close()
+
+        print("automatic failover complete")
+
+        return self.set(command)
 
     def serve(self):
         self.server.serve_forever()
 
     def shutdown(self):
-        print("Beginning load balancer shutdown")
+        print("beginning load balancer shutdown")
         for f_id in self.followers:
-            print(f"Shutting down node {f_id}")
+            print(f"shutting down node {f_id}")
             _, s = call_node_with_command(Shutdown(), f_id)
             s.close()
         self.server.socket.close()
 
-        print("Completed load balancer shutdown")
+        print("completed load balancer shutdown")

--- a/kvstore/loadbalancer.py
+++ b/kvstore/loadbalancer.py
@@ -29,11 +29,18 @@ class LoadBalancer:
             print(f"Registered node {command.node_number} as a follower")
             self.followers.add(command.node_number)
 
+        return StringResponse("ack")
+
     def get(self, command):
         if len(self.followers) == 0:
             return StringResponse("No nodes available")
+
+        # TODO: handle dead nodes
         get_node = random.sample(self.followers, 1)[0]
-        return call_node_with_command(command, get_node)
+        print(f"Reading from node {get_node}")
+        resp, socket = call_node_with_command(command, get_node)
+        socket.close()
+        return resp
 
     def serve(self):
         self.server.serve_forever()

--- a/kvstore/loadbalancer.py
+++ b/kvstore/loadbalancer.py
@@ -25,11 +25,13 @@ class LoadBalancer:
             print(f"Registered node {command.node_number} as the leader")
             self.leader = command.node_number
             self.followers.add(command.node_number)
+            return LBRegistrationInfo(LEADER_NODE, self.followers - set([command.node_number]))
         else:
             print(f"Registered node {command.node_number} as a follower")
             self.followers.add(command.node_number)
+            return LBRegistrationInfo(LEADER_NODE, set())
 
-        return StringResponse("ack")
+
 
     def get(self, command):
         if len(self.followers) == 0:

--- a/kvstore/loadbalancer.py
+++ b/kvstore/loadbalancer.py
@@ -1,0 +1,40 @@
+import socketserver
+
+from kvstore.constants import ENTRYPOINT_SOCKET
+from kvstore.encoding import *
+from kvstore.sockets import EntryPointHandler
+import socket
+
+
+class LoadBalancer:
+    def __init__(self, node_number):
+        self.node_number = node_number
+        self.en = BinaryEncoderDecoder()
+        sockFd = get_socket_fd(node_number)
+        self.server = socketserver.UnixStreamServer(sockFd, EntryPointHandler)
+        self.server.server = self
+
+        print("Starting loadbalancer")
+
+    def handle(self, data):
+        try:
+            command = self.en.decode(data)
+        except InputValidationError as e:
+            return str(e)
+
+        if command.enum == CommandEnum.GET:
+            result = self.get(command)
+        elif command.enum == CommandEnum.SET:
+            result = self.set(command)
+        elif command.enum == CommandEnum.REGISTER_FOLLOWER:
+            result = self.registerFollower(command)
+        elif command.enum == CommandEnum.WRITE_LOG:
+            result = self.receiveWriteLog(command)
+
+        return result
+
+    def serve(self):
+        self.server.serve_forever()
+
+    def shutdown(self):
+        self.server.socket.close()

--- a/kvstore/loadbalancer.py
+++ b/kvstore/loadbalancer.py
@@ -1,23 +1,23 @@
 import random
+import socket
 import socketserver
 
 from kvstore.constants import ENTRYPOINT_SOCKET
 from kvstore.encoding import *
 from kvstore.transport import EntryPointHandler, call_node_with_command, get_socket_fd
-import socket
 
 
 class LoadBalancer:
     def __init__(self, node_number, automatic_failover):
         self.node_number = node_number
+        self.automatic_failover = automatic_failover
+        self.leader = None
+        self.followers = set()
+
         self.en = BinaryEncoderDecoder()
         sockFd = get_socket_fd(node_number)
         self.server = socketserver.UnixStreamServer(sockFd, EntryPointHandler)
         self.server.server = self
-        self.automatic_failover = automatic_failover
-
-        self.leader = None
-        self.followers = set()
 
         print("starting loadbalancer")
 

--- a/kvstore/loadbalancer.py
+++ b/kvstore/loadbalancer.py
@@ -46,4 +46,11 @@ class LoadBalancer:
         self.server.serve_forever()
 
     def shutdown(self):
+        print("Beginning load balancer shutdown")
+        for f_id in self.followers:
+            print(f"Shutting down node {f_id}")
+            _, s = call_node_with_command(Shutdown(), f_id)
+            s.close()
         self.server.socket.close()
+        
+        print("Completed load balancer shutdown")

--- a/kvstore/server.py
+++ b/kvstore/server.py
@@ -19,8 +19,12 @@ class Server:
 
         print("starting server on node %s" % node_number)
         print("registering with load balancer")
-        command, s = call_node_with_command(self._register_command(), LB_NODE)
-        s.close()
+        try:
+            command, s = call_node_with_command(self._register_command(), LB_NODE)
+            s.close()
+        except FileNotFoundError:
+            print("could not reach the load balancer")
+            self.shutdown()
 
         self.receive_registration_info(command)
 
@@ -41,7 +45,6 @@ class Server:
     def receive_shutdown_instruction(self, command):
         print("received instruction to shut down. Initiating shut down...")
         self.shutdown()
-        sys.exit(0)
 
     def receive_registration_info(self, command):
         self.leader_node = command.leader_id
@@ -106,3 +109,4 @@ class Server:
     def shutdown(self):
         print("shutting down server")
         self.server.socket.close()
+        sys.exit(0)

--- a/kvstore/server.py
+++ b/kvstore/server.py
@@ -86,7 +86,7 @@ class Server:
             return Snapshot(store, log_sequence_number)
 
     def receiveWriteLog(self, command):
-        print(f"received write log {command}")
+        print(f"received write log")
         self.store.receive_write_log(command)
 
         return StringResponse("ack")

--- a/kvstore/store.py
+++ b/kvstore/store.py
@@ -41,7 +41,7 @@ class KVStore:
     def write_to_disk(self, command):
         # update log sequence number
         self.log_sequence_number += 1
-        print(f"log_sequence_number: {self.log_sequence_number}")
+        print(f"writing log_sequence_number {self.log_sequence_number} to disk")
 
         self.dump_db()
 

--- a/kvstore/transport.py
+++ b/kvstore/transport.py
@@ -21,6 +21,8 @@ class EntryPointHandler(socketserver.BaseRequestHandler):
                 result = self.server.server.registerFollower(command)
             elif command.enum == CommandEnum.WRITE_LOG:
                 result = self.server.server.receiveWriteLog(command)
+            elif command.enum == CommandEnum.SHUTDOWN:
+                result = self.server.server.receive_shutdown_instruction(command)
 
             return result
         except Exception as e:

--- a/kvstore/transport.py
+++ b/kvstore/transport.py
@@ -1,0 +1,39 @@
+import os
+import socket
+import socketserver
+
+from kvstore.constants import ENTRYPOINT_SOCKET
+from kvstore.encoding import *
+
+class EntryPointHandler(socketserver.BaseRequestHandler):
+    def handle(self):
+        data = self.request.recv(1024)
+        result = self.server.server.handle(data)
+        encoded = self.server.server.en.encode(result)
+        self.request.send(encoded)
+        return
+
+def call_node_with_command(command, node_number):
+    en = BinaryEncoderDecoder()
+    sockFd = get_socket_fd(node_number)
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.connect(sockFd)
+
+    encoded = en.encode(command)
+    s.send(encoded)
+
+    total = b''
+    while True:
+        response = s.recv(1024)
+        if len(response) == 0:
+            break
+        total += response
+
+    return en.decode(total), s
+
+def get_socket_fd(node_num):
+    return ENTRYPOINT_SOCKET + str(node_num)
+
+def unlink(sockfd):
+    if os.path.exists(sockfd):
+        os.unlink(sockfd)

--- a/kvstore/transport.py
+++ b/kvstore/transport.py
@@ -23,6 +23,8 @@ class EntryPointHandler(socketserver.BaseRequestHandler):
                 result = self.server.server.receiveWriteLog(command)
             elif command.enum == CommandEnum.SHUTDOWN:
                 result = self.server.server.receive_shutdown_instruction(command)
+            elif command.enum == CommandEnum.LB_REGISTRATION_INFO:
+                result = self.server.server.receive_registration_info(command)
 
             return result
         except Exception as e:

--- a/loadbalancer.py
+++ b/loadbalancer.py
@@ -9,7 +9,7 @@ if __name__ == '__main__':
     sockfd = get_socket_fd(node_number)
     atexit.register(unlink, sockfd)
 
-    lb = LoadBalancer(node_number)
+    lb = LoadBalancer(node_number, automatic_failover=True)
 
     try:
         lb.serve()

--- a/loadbalancer.py
+++ b/loadbalancer.py
@@ -1,21 +1,18 @@
 import atexit
-import sys
 
-from kvstore.server import Server
+from kvstore.loadbalancer import LoadBalancer
+from kvstore.server import get_socket_fd
 from kvstore.transport import get_socket_fd, unlink
 
 if __name__ == '__main__':
-    try:
-        node_number = int(sys.argv[1])
-    except IndexError:
-        node_number = 1
-
+    node_number = 0
     sockfd = get_socket_fd(node_number)
     atexit.register(unlink, sockfd)
-    server = Server(node_number)
+
+    lb = LoadBalancer(node_number)
 
     try:
-        server.serve()
+        lb.serve()
     except KeyboardInterrupt:
-        server.shutdown()
+        lb.shutdown()
         unlink(sockfd)

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -21,6 +21,7 @@ def test_bijection():
             ]
         ),
         Shutdown(),
+        EmptyResponse(),
         LBRegistrationInfo(1, set()),
         LBRegistrationInfo(2, set([1,2,4,5]))
     ]

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -19,7 +19,10 @@ def test_bijection():
                 WriteLog("asdfasdf", "1231", 11),
                 WriteLog("adfd", "bsfsdf", 12),
             ]
-        )
+        ),
+        Shutdown(),
+        LBRegistrationInfo(1, set()),
+        LBRegistrationInfo(2, set([1,2,4,5]))
     ]
     for command in test_cases:
         assert command == en.decode(en.encode(command))


### PR DESCRIPTION
**Scaling Reads to Read Replicas**

- Adds a load balancer that proxies all requests from clients
- Server nodes register with the load balancer and are told whether or not they're the leader, and if they are the leader, they're told about any other follower nodes that are already running
- The load balancer randomly allocates reads among the leader and its followers; if an individual node is unavailable for reads, it is marked dead and the load balancer tries another node. If all read replicas are unavailable, the load balancer returns an error
- The load balancer proxies write requests to the leader. If the leader is unavailable, the load balancer returns an error
- When the load balancer shuts down, it issues a shutdown command to all other nodes - this ensures we never have any nodes running that the load balancer isn't aware of
- Automatic failover for writes